### PR TITLE
Allow adding new RTField to index with empty string default

### DIFF
--- a/manticore/backend/schema.py
+++ b/manticore/backend/schema.py
@@ -61,11 +61,22 @@ class DatabaseSchemaEditor(schema.DatabaseSchemaEditor):
         """
         # calling BaseDatabaseSchemaEditor.add_field to skip mysql
         # implementation
+        # noinspection PyUnresolvedReferences
         super(schema.DatabaseSchemaEditor, self).add_field(model, field)
 
         if (self.skip_default(field) and
                 field.default not in (None, NOT_PROVIDED)):
             effective_default = self.effective_default(field)
+
+            if isinstance(field, fields.RTField):
+                if effective_default != '':
+                    # RTField update is not supported by manticore, and there
+                    # is no data to preform REPLACE query (INSERT basically).
+                    raise ValueError("RTField default must be ''")
+                else:
+                    # empty string is default by default, no update is necessary
+                    return
+
             # UPDATE needs WHERE clause
             # noinspection SqlNoDataSourceInspection,PyProtectedMember
             self.execute(


### PR DESCRIPTION
* Django performs an update query with one-time default value while adding new column
* Manticore does not allow UPDATE query on RTField, and REPLACE can't be used automatically because it needs all fields values.